### PR TITLE
Add interactive shape-morphing particle display

### DIFF
--- a/src/app/_components/homepage/nav-list.tsx
+++ b/src/app/_components/homepage/nav-list.tsx
@@ -51,7 +51,7 @@ export default function NavList() {
       {/* Single particle canvas kept in one stable DOM position (so its WebGL
           context never remounts): shown up top on mobile via order-first, and
           inside the framed box on desktop. */}
-      <div className="order-first mb-12 flex justify-center lg:order-none lg:mb-0 lg:mt-10 lg:rounded-t-lg lg:border lg:border-zinc-800 lg:bg-slate-800/10 lg:p-10">
+      <div className="order-first mb-12 flex justify-center lg:order-none lg:mb-0 lg:mt-10 lg:rounded-t-lg lg:border lg:border-zinc-800 lg:bg-slate-800/10 lg:p-4">
         <ParticleDisplay />
       </div>
 

--- a/src/app/_components/homepage/particle-display/particle-display.tsx
+++ b/src/app/_components/homepage/particle-display/particle-display.tsx
@@ -3,7 +3,6 @@ import { OrbitControls } from "@react-three/drei";
 import { Canvas, useFrame } from "@react-three/fiber";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
-  MathUtils,
   AdditiveBlending,
   type Points,
   type BufferGeometry,
@@ -17,8 +16,182 @@ import { usePrefersReducedMotion } from "~/hooks/use-prefers-reduced-motion";
 import vertexShader from "./shaders/vertexShader.glsl";
 import fragmentShader from "./shaders/fragmentShader.glsl";
 
+const RADIUS = 0.45;
+const HOLD_SECONDS = 2.2; // dwell on each shape
+const MORPH_SECONDS = 1.6; // transition time between shapes
+
+// ---- Shape generators: each returns a Float32Array of `count` xyz points,
+// kept within ~RADIUS of the origin so the shader's size/colour math holds. ----
+
+type Build = (count: number) => Float32Array;
+
+const sphere: Build = (count) => {
+  const p = new Float32Array(count * 3);
+  for (let i = 0; i < count; i++) {
+    const theta = Math.random() * Math.PI * 2;
+    const phi = Math.acos(2 * Math.random() - 1);
+    // Volume fill (cube-root keeps density even) so distance-from-center
+    // varies — gives the orb a warmer, larger-pointed core.
+    const r = RADIUS * Math.cbrt(Math.random());
+    p.set(
+      [
+        r * Math.sin(phi) * Math.cos(theta),
+        r * Math.sin(phi) * Math.sin(theta),
+        r * Math.cos(phi),
+      ],
+      i * 3,
+    );
+  }
+  return p;
+};
+
+const cube: Build = (count) => {
+  const p = new Float32Array(count * 3);
+  const h = 0.3;
+  for (let i = 0; i < count; i++) {
+    const a = (Math.random() * 2 - 1) * h;
+    const b = (Math.random() * 2 - 1) * h;
+    const face = Math.floor(Math.random() * 6);
+    const xyz =
+      face === 0
+        ? [h, a, b]
+        : face === 1
+          ? [-h, a, b]
+          : face === 2
+            ? [a, h, b]
+            : face === 3
+              ? [a, -h, b]
+              : face === 4
+                ? [a, b, h]
+                : [a, b, -h];
+    p.set(xyz, i * 3);
+  }
+  return p;
+};
+
+const torus: Build = (count) => {
+  const p = new Float32Array(count * 3);
+  const R = 0.3;
+  const r = 0.12;
+  for (let i = 0; i < count; i++) {
+    const u = Math.random() * Math.PI * 2;
+    const v = Math.random() * Math.PI * 2;
+    p.set(
+      [
+        (R + r * Math.cos(v)) * Math.cos(u),
+        r * Math.sin(v),
+        (R + r * Math.cos(v)) * Math.sin(u),
+      ],
+      i * 3,
+    );
+  }
+  return p;
+};
+
+const galaxy: Build = (count) => {
+  const p = new Float32Array(count * 3);
+  const arms = 3;
+  for (let i = 0; i < count; i++) {
+    const t = Math.random();
+    const dist = t * 0.42;
+    const arm = Math.floor(Math.random() * arms);
+    const angle = arm * ((Math.PI * 2) / arms) + dist * 7.0;
+    const jitter = (Math.random() - 0.5) * 0.05;
+    p.set(
+      [
+        Math.cos(angle) * dist + jitter,
+        (Math.random() - 0.5) * 0.05 * (1 - t * 0.7),
+        Math.sin(angle) * dist + jitter,
+      ],
+      i * 3,
+    );
+  }
+  return p;
+};
+
+const SHAPE_BUILDERS: Build[] = [sphere, galaxy, torus, cube];
+
+function easeInOutCubic(x: number) {
+  return x < 0.5 ? 4 * x * x * x : 1 - Math.pow(-2 * x + 2, 3) / 2;
+}
+
+type ParticlesProps = {
+  count: number;
+  reducedMotion: boolean;
+  advanceRef: React.RefObject<boolean>;
+};
+
+const MorphingParticles = ({ count, reducedMotion, advanceRef }: ParticlesProps) => {
+  const points = useRef<Points<BufferGeometry, ShaderMaterial>>(null!);
+
+  // Generate every shape once (lazy initializer keeps the RNG out of render).
+  const [shapes] = useState(() => SHAPE_BUILDERS.map((build) => build(count)));
+  const [render] = useState(() => shapes[0]!.slice()); // mutable buffer fed to the GPU
+
+  const uniforms = useMemo(
+    () => ({ uTime: { value: 0 }, uRadius: { value: 0.5 } }),
+    [],
+  );
+
+  const morph = useRef({ from: 0, to: 1 % shapes.length, t: 0, hold: HOLD_SECONDS });
+
+  useFrame((state, delta) => {
+    // Reduced motion: freeze the field entirely (no shimmer, no morph).
+    if (reducedMotion) return;
+
+    const dt = Math.min(delta, 0.05); // clamp to avoid jumps after tab refocus
+    // Mutate via the material ref (not the memoized uniforms object directly).
+    const uTime = points.current?.material.uniforms.uTime;
+    if (uTime) uTime.value = state.clock.elapsedTime;
+
+    const m = morph.current;
+    if (advanceRef.current) {
+      advanceRef.current = false;
+      m.hold = 0; // a click skips the remaining dwell
+    }
+
+    if (m.hold > 0) {
+      m.hold -= dt;
+    } else {
+      m.t += dt / MORPH_SECONDS;
+      if (m.t >= 1) {
+        m.t = 0;
+        m.from = m.to;
+        m.to = (m.to + 1) % shapes.length;
+        m.hold = HOLD_SECONDS;
+      }
+    }
+
+    const f = easeInOutCubic(Math.min(m.t, 1));
+    const attr = points.current?.geometry.attributes.position;
+    if (attr) {
+      const arr = attr.array as Float32Array;
+      const A = shapes[m.from]!;
+      const B = shapes[m.to]!;
+      for (let i = 0; i < arr.length; i++) arr[i] = A[i]! + (B[i]! - A[i]!) * f;
+      attr.needsUpdate = true;
+    }
+  });
+
+  return (
+    <points ref={points}>
+      <bufferGeometry>
+        <bufferAttribute attach="attributes-position" args={[render, 3]} />
+      </bufferGeometry>
+      <shaderMaterial
+        depthWrite={false}
+        fragmentShader={fragmentShader}
+        vertexShader={vertexShader}
+        uniforms={uniforms}
+        blending={AdditiveBlending}
+      />
+    </points>
+  );
+};
+
 export const ParticleDisplay = ({ count = 10000 }: { count?: number }) => {
   const prefersReducedMotion = usePrefersReducedMotion();
+  const advanceRef = useRef(false);
 
   useEffect(() => {
     if (prefersReducedMotion) return;
@@ -31,88 +204,31 @@ export const ParticleDisplay = ({ count = 10000 }: { count?: number }) => {
   return (
     <div
       aria-hidden="true"
-      className="particle-display flex h-[300px] w-[300px] items-center  justify-center"
+      title="Drag to rotate · scroll to zoom · click to change shape"
+      onClick={() => {
+        advanceRef.current = true;
+      }}
+      className="particle-display flex aspect-square w-full max-w-[320px] items-center justify-center lg:max-w-[420px]"
     >
       <Canvas
-        className="flex "
-        camera={{ position: [1.5, 1.5, 1.5], zoom: 4, near: 1, far: 1000 }}
+        camera={{ position: [1.5, 1.5, 1.5], fov: 50, near: 0.1, far: 100, zoom: 2.4 }}
       >
-        <OrbitControls />
-        <CustomGeometryParticles count={count} reducedMotion={prefersReducedMotion} />
+        <OrbitControls
+          makeDefault
+          enablePan={false}
+          enableZoom
+          minDistance={1.2}
+          maxDistance={5}
+          enableDamping
+          autoRotate={!prefersReducedMotion}
+          autoRotateSpeed={0.6}
+        />
+        <MorphingParticles
+          count={count}
+          reducedMotion={prefersReducedMotion}
+          advanceRef={advanceRef}
+        />
       </Canvas>
     </div>
-  );
-};
-
-type CustomGeometryParticlesProps = {
-  count: number;
-  reducedMotion: boolean;
-};
-
-const CustomGeometryParticles = ({
-  count,
-  reducedMotion,
-}: CustomGeometryParticlesProps) => {
-  const radius = 0.5;
-
-  // This reference gives us direct access to our points
-  const points = useRef<Points<BufferGeometry, ShaderMaterial>>(null!);
-
-  // Particle positions are randomized once on mount. A lazy useState
-  // initializer keeps the impure random generation out of render (React 19
-  // purity rule) while still running a single time.
-  const [particlesPosition] = useState(() => {
-    const positions = new Float32Array(count * 3);
-
-    for (let i = 0; i < count; i++) {
-      const distance = Math.sqrt(Math.random()) * radius;
-      const theta = MathUtils.randFloatSpread(360);
-      const phi = MathUtils.randFloatSpread(360);
-
-      const x = distance * Math.sin(theta) * Math.cos(phi);
-      const y = distance * Math.sin(theta) * Math.sin(phi);
-      const z = distance * Math.cos(theta);
-
-      positions.set([x, y, z], i * 3);
-    }
-
-    return positions;
-  });
-
-  const uniforms = useMemo(
-    () => ({
-      uTime: {
-        value: 0.0,
-      },
-      uRadius: {
-        value: radius,
-      },
-    }),
-    [],
-  );
-
-  useFrame(({ clock }) => {
-    // Freeze the field for users who prefer reduced motion.
-    if (reducedMotion) return;
-    const uTime = points.current?.material.uniforms.uTime;
-    if (uTime) uTime.value = clock.elapsedTime;
-  });
-
-  return (
-    <points ref={points}>
-      <bufferGeometry>
-        <bufferAttribute
-          attach="attributes-position"
-          args={[particlesPosition, 3]}
-        />
-      </bufferGeometry>
-      <shaderMaterial
-        depthWrite={false}
-        fragmentShader={fragmentShader}
-        vertexShader={vertexShader}
-        uniforms={uniforms}
-        blending={AdditiveBlending}
-      />
-    </points>
   );
 };

--- a/src/app/_components/homepage/particle-display/shaders/vertexShader.glsl
+++ b/src/app/_components/homepage/particle-display/shaders/vertexShader.glsl
@@ -3,33 +3,16 @@ uniform float uRadius;
 
 varying float vDistance;
 
-// Source: https://github.com/dmnsgn/glsl-rotate/blob/main/rotation-3d-y.glsl.js
-mat3 rotation3dY(float angle) {
-  float s = sin(angle);
-  float c = cos(angle);
-  return mat3(
-    c, 0.0, -s,
-    0.0, 1.0, 0.0,
-    s, 0.0, c
-  );
-}
-
-// Source: https://github.com/dmnsgn/glsl-rotate/blob/main/rotation-3d-x.glsl.js
-mat3 rotation3dX(float angle) {
-  float s = sin(angle);
-  float c = cos(angle);
-  return mat3(
-    1.0, 0.0, 0.0,
-    0.0, c, s,
-    0.0, -s, c
-  );
-}
-
-
 void main() {
-  float distanceFactor = pow(uRadius - distance(position, vec3(0.0)), 1.5);
-  float size = distanceFactor * 10.0 + 10.0;
-  vec3 particlePosition = position * rotation3dX(uTime * 0.3 * distanceFactor);
+  float d = distance(position, vec3(0.0));
+  // Clamp so shapes larger than uRadius don't produce NaN sizes.
+  float distanceFactor = pow(max(uRadius - d, 0.0), 1.5);
+
+  // Gentle radial shimmer that keeps the shape recognizable (no full twist).
+  vec3 dir = normalize(position + vec3(1e-4));
+  vec3 particlePosition = position + dir * sin(uTime * 1.5 + d * 14.0) * 0.012;
+
+  float size = distanceFactor * 12.0 + 6.0;
 
   vDistance = distanceFactor;
 


### PR DESCRIPTION
- Particles now morph between four shapes (sphere, galaxy, torus, cube) on an auto-cycle, with click-to-advance and OrbitControls drag/zoom plus a gentle auto-rotate. Reduced-motion freezes to a static sphere.
- Shapes are generated once (lazy useState) and CPU-lerped with eased transitions; the vertex shader's unbounded per-particle twist is replaced by a small shape-preserving shimmer so shapes stay recognizable, and the radius math is clamped against NaN.
- Fill the parent box on desktop: responsive square canvas (was a fixed 300x300), smaller box padding, and a tuned camera so the field reaches the edges.
- Volume-fill sphere (warm, varied core) and slightly smaller cube to avoid clipping.