### PR TITLE
Rework particle card: shape toggles, computer-themed shapes, publications icon

### DIFF
--- a/src/app/_components/homepage/nav-list.tsx
+++ b/src/app/_components/homepage/nav-list.tsx
@@ -51,19 +51,11 @@ export default function NavList() {
       {/* Single particle canvas kept in one stable DOM position (so its WebGL
           context never remounts): shown up top on mobile via order-first, and
           inside the framed box on desktop. */}
-      <div className="order-first mb-12 flex justify-center lg:order-none lg:mb-0 lg:mt-10 lg:rounded-t-lg lg:border lg:border-zinc-800 lg:bg-slate-800/10 lg:p-4">
+      {/* Single particle canvas kept in one stable DOM position (so its WebGL
+          context never remounts): shown up top on mobile via order-first, and
+          inside the framed card on desktop. */}
+      <div className="order-first mb-12 flex justify-center lg:order-none lg:mb-0 lg:mt-10 lg:rounded-lg lg:border lg:border-zinc-800 lg:bg-slate-800/10 lg:p-4">
         <ParticleDisplay />
-      </div>
-
-      <div className="flex flex-row justify-center px-4 border p-2.5 rounded-b-lg bg-slate-800/20 border-zinc-800 text-sm font-light text-white/75 w-full">
-        <a
-          href={"https://ieeexplore.ieee.org/author/37087008577"}
-          target="_blank"
-          rel="noreferrer"
-          className="hover:text-white hover:scale-105"
-        >
-          publications
-        </a>
       </div>
 
       <ul className="social-links mt-4 flex w-full flex-row justify-evenly lg:mt-8">
@@ -135,6 +127,37 @@ export default function NavList() {
               <path stroke="none" d="M0 0h24v24H0z" fill="none" />
               <path d="M22 7.535v9.465a3 3 0 0 1 -2.824 2.995l-.176 .005h-14a3 3 0 0 1 -2.995 -2.824l-.005 -.176v-9.465l9.445 6.297l.116 .066a1 1 0 0 0 .878 0l.116 -.066l9.445 -6.297z" />
               <path d="M19 4c1.08 0 2.027 .57 2.555 1.427l-9.555 6.37l-9.555 -6.37a2.999 2.999 0 0 1 2.354 -1.42l.201 -.007h14z" />
+            </svg>
+          </a>
+        </li>
+
+        <li className="text-zinc-400">
+          <a
+            href="https://ieeexplore.ieee.org/author/37087008577"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Publications (IEEE)"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+              focusable="false"
+              className="icon icon-tabler icons-tabler-outline icon-tabler-file-text"
+            >
+              <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+              <path d="M14 3v4a1 1 0 0 0 1 1h4" />
+              <path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" />
+              <path d="M9 9l1 0" />
+              <path d="M9 13l6 0" />
+              <path d="M9 17l6 0" />
             </svg>
           </a>
         </li>

--- a/src/app/_components/homepage/particle-display/particle-display.tsx
+++ b/src/app/_components/homepage/particle-display/particle-display.tsx
@@ -17,8 +17,8 @@ import vertexShader from "./shaders/vertexShader.glsl";
 import fragmentShader from "./shaders/fragmentShader.glsl";
 
 const RADIUS = 0.45;
-const HOLD_SECONDS = 2.2; // dwell on each shape
 const MORPH_SECONDS = 1.6; // transition time between shapes
+const CYCLE_MS = 4200; // auto-advance cadence
 
 // ---- Shape generators: each returns a Float32Array of `count` xyz points,
 // kept within ~RADIUS of the origin so the shader's size/colour math holds. ----
@@ -38,6 +38,46 @@ const sphere: Build = (count) => {
         r * Math.sin(phi) * Math.cos(theta),
         r * Math.sin(phi) * Math.sin(theta),
         r * Math.cos(phi),
+      ],
+      i * 3,
+    );
+  }
+  return p;
+};
+
+const galaxy: Build = (count) => {
+  const p = new Float32Array(count * 3);
+  const arms = 3;
+  for (let i = 0; i < count; i++) {
+    const t = Math.random();
+    const dist = t * 0.42;
+    const arm = Math.floor(Math.random() * arms);
+    const angle = arm * ((Math.PI * 2) / arms) + dist * 7.0;
+    const jitter = (Math.random() - 0.5) * 0.05;
+    p.set(
+      [
+        Math.cos(angle) * dist + jitter,
+        (Math.random() - 0.5) * 0.05 * (1 - t * 0.7),
+        Math.sin(angle) * dist + jitter,
+      ],
+      i * 3,
+    );
+  }
+  return p;
+};
+
+const torus: Build = (count) => {
+  const p = new Float32Array(count * 3);
+  const R = 0.3;
+  const r = 0.12;
+  for (let i = 0; i < count; i++) {
+    const u = Math.random() * Math.PI * 2;
+    const v = Math.random() * Math.PI * 2;
+    p.set(
+      [
+        (R + r * Math.cos(v)) * Math.cos(u),
+        r * Math.sin(v),
+        (R + r * Math.cos(v)) * Math.sin(u),
       ],
       i * 3,
     );
@@ -69,18 +109,24 @@ const cube: Build = (count) => {
   return p;
 };
 
-const torus: Build = (count) => {
+// 3D lattice — particles cluster tightly at each grid node so it reads as a
+// crisp data cube / matrix of points rather than a fuzzy cloud.
+const grid: Build = (count) => {
   const p = new Float32Array(count * 3);
-  const R = 0.3;
-  const r = 0.12;
+  const n = 9; // 9 x 9 x 9 = 729 nodes
+  const nodes = n * n * n;
+  const span = 0.74;
+  const jitter = 0.008;
   for (let i = 0; i < count; i++) {
-    const u = Math.random() * Math.PI * 2;
-    const v = Math.random() * Math.PI * 2;
+    const node = i % nodes; // spread particles evenly across nodes
+    const ix = node % n;
+    const iy = Math.floor(node / n) % n;
+    const iz = Math.floor(node / (n * n)) % n;
     p.set(
       [
-        (R + r * Math.cos(v)) * Math.cos(u),
-        r * Math.sin(v),
-        (R + r * Math.cos(v)) * Math.sin(u),
+        (ix / (n - 1) - 0.5) * span + (Math.random() - 0.5) * jitter,
+        (iy / (n - 1) - 0.5) * span + (Math.random() - 0.5) * jitter,
+        (iz / (n - 1) - 0.5) * span + (Math.random() - 0.5) * jitter,
       ],
       i * 3,
     );
@@ -88,28 +134,28 @@ const torus: Build = (count) => {
   return p;
 };
 
-const galaxy: Build = (count) => {
+// Rippling surface — reads like a signal / waveform.
+const wave: Build = (count) => {
   const p = new Float32Array(count * 3);
-  const arms = 3;
+  const span = 0.82;
   for (let i = 0; i < count; i++) {
-    const t = Math.random();
-    const dist = t * 0.42;
-    const arm = Math.floor(Math.random() * arms);
-    const angle = arm * ((Math.PI * 2) / arms) + dist * 7.0;
-    const jitter = (Math.random() - 0.5) * 0.05;
-    p.set(
-      [
-        Math.cos(angle) * dist + jitter,
-        (Math.random() - 0.5) * 0.05 * (1 - t * 0.7),
-        Math.sin(angle) * dist + jitter,
-      ],
-      i * 3,
-    );
+    const x = (Math.random() - 0.5) * span;
+    const z = (Math.random() - 0.5) * span;
+    const d = Math.sqrt(x * x + z * z);
+    const y = Math.sin(d * 16.0) * 0.07 + Math.sin(x * 10.0) * 0.02;
+    p.set([x, y, z], i * 3);
   }
   return p;
 };
 
-const SHAPE_BUILDERS: Build[] = [sphere, galaxy, torus, cube];
+const SHAPES: { name: string; build: Build }[] = [
+  { name: "Orb", build: sphere },
+  { name: "Galaxy", build: galaxy },
+  { name: "Torus", build: torus },
+  { name: "Cube", build: cube },
+  { name: "Grid", build: grid },
+  { name: "Wave", build: wave },
+];
 
 function easeInOutCubic(x: number) {
   return x < 0.5 ? 4 * x * x * x : 1 - Math.pow(-2 * x + 2, 3) / 2;
@@ -117,58 +163,58 @@ function easeInOutCubic(x: number) {
 
 type ParticlesProps = {
   count: number;
+  active: number;
   reducedMotion: boolean;
-  advanceRef: React.RefObject<boolean>;
 };
 
-const MorphingParticles = ({ count, reducedMotion, advanceRef }: ParticlesProps) => {
+const MorphingParticles = ({ count, active, reducedMotion }: ParticlesProps) => {
   const points = useRef<Points<BufferGeometry, ShaderMaterial>>(null!);
 
-  // Generate every shape once (lazy initializer keeps the RNG out of render).
-  const [shapes] = useState(() => SHAPE_BUILDERS.map((build) => build(count)));
-  const [render] = useState(() => shapes[0]!.slice()); // mutable buffer fed to the GPU
+  // Build every shape once (lazy initializer keeps the RNG out of render).
+  const [shapes] = useState(() => SHAPES.map((s) => s.build(count)));
+  const [renderBuffer] = useState(() => shapes[0]!.slice());
 
   const uniforms = useMemo(
     () => ({ uTime: { value: 0 }, uRadius: { value: 0.5 } }),
     [],
   );
 
-  const morph = useRef({ from: 0, to: 1 % shapes.length, t: 0, hold: HOLD_SECONDS });
+  // Tracks the in-flight morph: which shape we're showing and the lerp source.
+  const morph = useRef({ shown: 0, from: shapes[0]!.slice(), t: 1 });
 
   useFrame((state, delta) => {
-    // Reduced motion: freeze the field entirely (no shimmer, no morph).
-    if (reducedMotion) return;
+    const attr = points.current?.geometry.attributes.position;
+    if (!attr) return;
+    const arr = attr.array as Float32Array;
+    const m = morph.current;
+
+    if (reducedMotion) {
+      // Snap to the active shape, no animation or shimmer.
+      if (m.shown !== active) {
+        arr.set(shapes[active]!);
+        attr.needsUpdate = true;
+        m.shown = active;
+      }
+      return;
+    }
 
     const dt = Math.min(delta, 0.05); // clamp to avoid jumps after tab refocus
-    // Mutate via the material ref (not the memoized uniforms object directly).
     const uTime = points.current?.material.uniforms.uTime;
     if (uTime) uTime.value = state.clock.elapsedTime;
 
-    const m = morph.current;
-    if (advanceRef.current) {
-      advanceRef.current = false;
-      m.hold = 0; // a click skips the remaining dwell
+    // Active changed → start a fresh morph from wherever we currently are.
+    if (m.shown !== active) {
+      m.from.set(arr);
+      m.shown = active;
+      m.t = 0;
     }
 
-    if (m.hold > 0) {
-      m.hold -= dt;
-    } else {
-      m.t += dt / MORPH_SECONDS;
-      if (m.t >= 1) {
-        m.t = 0;
-        m.from = m.to;
-        m.to = (m.to + 1) % shapes.length;
-        m.hold = HOLD_SECONDS;
-      }
-    }
-
-    const f = easeInOutCubic(Math.min(m.t, 1));
-    const attr = points.current?.geometry.attributes.position;
-    if (attr) {
-      const arr = attr.array as Float32Array;
-      const A = shapes[m.from]!;
-      const B = shapes[m.to]!;
-      for (let i = 0; i < arr.length; i++) arr[i] = A[i]! + (B[i]! - A[i]!) * f;
+    if (m.t < 1) {
+      m.t = Math.min(1, m.t + dt / MORPH_SECONDS);
+      const f = easeInOutCubic(m.t);
+      const target = shapes[active]!;
+      for (let i = 0; i < arr.length; i++)
+        arr[i] = m.from[i]! + (target[i]! - m.from[i]!) * f;
       attr.needsUpdate = true;
     }
   });
@@ -176,7 +222,7 @@ const MorphingParticles = ({ count, reducedMotion, advanceRef }: ParticlesProps)
   return (
     <points ref={points}>
       <bufferGeometry>
-        <bufferAttribute attach="attributes-position" args={[render, 3]} />
+        <bufferAttribute attach="attributes-position" args={[renderBuffer, 3]} />
       </bufferGeometry>
       <shaderMaterial
         depthWrite={false}
@@ -191,7 +237,19 @@ const MorphingParticles = ({ count, reducedMotion, advanceRef }: ParticlesProps)
 
 export const ParticleDisplay = ({ count = 10000 }: { count?: number }) => {
   const prefersReducedMotion = usePrefersReducedMotion();
-  const advanceRef = useRef(false);
+  const [active, setActive] = useState(0);
+
+  // Auto-cycle through shapes; a manual pick (below) resets the timer because
+  // `active` is a dependency, so the field dwells on a chosen shape before
+  // resuming.
+  useEffect(() => {
+    if (prefersReducedMotion) return;
+    const id = setInterval(
+      () => setActive((a) => (a + 1) % SHAPES.length),
+      CYCLE_MS,
+    );
+    return () => clearInterval(id);
+  }, [prefersReducedMotion, active]);
 
   useEffect(() => {
     if (prefersReducedMotion) return;
@@ -202,33 +260,55 @@ export const ParticleDisplay = ({ count = 10000 }: { count?: number }) => {
   }, [prefersReducedMotion]);
 
   return (
-    <div
-      aria-hidden="true"
-      title="Drag to rotate · scroll to zoom · click to change shape"
-      onClick={() => {
-        advanceRef.current = true;
-      }}
-      className="particle-display flex aspect-square w-full max-w-[320px] items-center justify-center lg:max-w-[420px]"
-    >
-      <Canvas
-        camera={{ position: [1.5, 1.5, 1.5], fov: 50, near: 0.1, far: 100, zoom: 2.4 }}
+    <div className="flex w-full flex-col items-center gap-3">
+      <div
+        aria-hidden="true"
+        title="Drag to rotate · scroll to zoom · click to change shape"
+        onClick={() => setActive((a) => (a + 1) % SHAPES.length)}
+        className="particle-display flex aspect-square w-full max-w-[320px] items-center justify-center lg:max-w-[420px]"
       >
-        <OrbitControls
-          makeDefault
-          enablePan={false}
-          enableZoom
-          minDistance={1.2}
-          maxDistance={5}
-          enableDamping
-          autoRotate={!prefersReducedMotion}
-          autoRotateSpeed={0.6}
-        />
-        <MorphingParticles
-          count={count}
-          reducedMotion={prefersReducedMotion}
-          advanceRef={advanceRef}
-        />
-      </Canvas>
+        <Canvas
+          camera={{ position: [1.5, 1.5, 1.5], fov: 50, near: 0.1, far: 100, zoom: 2.4 }}
+        >
+          <OrbitControls
+            makeDefault
+            enablePan={false}
+            enableZoom
+            minDistance={1.2}
+            maxDistance={5}
+            enableDamping
+            autoRotate={!prefersReducedMotion}
+            autoRotateSpeed={0.6}
+          />
+          <MorphingParticles
+            count={count}
+            active={active}
+            reducedMotion={prefersReducedMotion}
+          />
+        </Canvas>
+      </div>
+
+      <div
+        role="group"
+        aria-label="Particle shape"
+        className="flex flex-wrap justify-center gap-1.5"
+      >
+        {SHAPES.map((s, i) => (
+          <button
+            key={s.name}
+            type="button"
+            onClick={() => setActive(i)}
+            aria-pressed={active === i}
+            className={`rounded-full px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wide transition-colors ${
+              active === i
+                ? "bg-[#5786F5]/30 text-white"
+                : "bg-[#6071e2]/10 text-zinc-400 hover:text-white"
+            }`}
+          >
+            {s.name}
+          </button>
+        ))}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Reworks the particle card and makes the field interactive.

## Card
- Move **publications** out of its odd text half-card into the social icon row (new aria-labelled file-text icon).
- The particle display is now a single, fully-rounded standalone card.

## Interactivity
- Add an accessible **shape toggle** button group (`Orb · Galaxy · Torus · Cube · Grid · Wave`) below the canvas. Picking a shape morphs to it and highlights it; auto-cycle dwells then resumes. Clicking the canvas still advances; drag/zoom/auto-rotate unchanged.
- Two new **computer-themed shapes**: a 3D **Grid** (crisp lattice of nodes — a data cube/matrix) and a **Wave** signal surface, alongside the existing orb/galaxy/torus/cube.
- Morphing is driven from one shared `active` state so buttons, canvas-click, and auto-cycle all use the same path.

## Accessibility
- Reduced-motion **snaps** between shapes without animating and freezes the field; the canvas stays `aria-hidden` while the toggle buttons are real, focusable controls.

## Verification
- `npm run lint` ✓ · `npm run build` ✓ · `npm run smoke` ✓ (live WebGL context, cursor glow intact, no console errors across desktop / mobile / reduced-motion).
- Each shape and the toggle interaction were visually confirmed via headless-browser screenshots.
