### PR TITLE
Full-bleed ambient particle background

### DIFF
--- a/src/app/_components/homepage/nav-list.tsx
+++ b/src/app/_components/homepage/nav-list.tsx
@@ -3,19 +3,9 @@
 import { useEffect } from "react";
 import { animate, type AnimationSequence } from "motion";
 
-import dynamic from "next/dynamic";
 import Link from "next/link";
 
 import { usePrefersReducedMotion } from "~/hooks/use-prefers-reduced-motion";
-
-// The Three.js <Canvas> relies on react-reconciler, which can't be server-rendered
-// during Next's static export (it reads React internals that are undefined on the
-// server). Load it browser-only so the rest of the page still prerenders.
-const ParticleDisplay = dynamic(
-  () =>
-    import("./particle-display/particle-display").then((m) => m.ParticleDisplay),
-  { ssr: false },
-);
 
 export default function NavList() {
   const prefersReducedMotion = usePrefersReducedMotion();
@@ -46,16 +36,6 @@ export default function NavList() {
           I design and build highly performant, mission-critical systems for all
           domains.
         </p>
-      </div>
-
-      {/* Single particle canvas kept in one stable DOM position (so its WebGL
-          context never remounts): shown up top on mobile via order-first, and
-          inside the framed box on desktop. */}
-      {/* Single particle canvas kept in one stable DOM position (so its WebGL
-          context never remounts): shown up top on mobile via order-first, and
-          inside the framed card on desktop. */}
-      <div className="order-first mb-12 flex justify-center lg:order-none lg:mb-0 lg:mt-10 lg:rounded-lg lg:border lg:border-zinc-800 lg:bg-slate-800/10 lg:p-4">
-        <ParticleDisplay />
       </div>
 
       <ul className="social-links mt-4 flex w-full flex-row justify-evenly lg:mt-8">

--- a/src/app/_components/homepage/particle-display/particle-display.tsx
+++ b/src/app/_components/homepage/particle-display/particle-display.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { OrbitControls } from "@react-three/drei";
 import { Canvas, useFrame } from "@react-three/fiber";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -20,6 +19,12 @@ import fragmentShader from "./shaders/fragmentShader.glsl";
 const RADIUS = 0.45;
 const MORPH_SECONDS = 1.6;
 const CYCLE_MS = 4200;
+
+// --- Background tuning knobs (safe to change by number; no WebGL needed) ---
+const COUNT = 20000; // particle count — higher = denser, bigger-feeling shapes
+const CAMERA_ZOOM = 3.0; // higher = the shape fills more of the screen
+const BG_OPACITY = 0.6; // overall background subtlety (readability vs presence)
+const AUTO_ROTATE = 0.12; // radians/sec the field slowly spins
 
 type Build = (count: number) => Float32Array;
 
@@ -412,6 +417,8 @@ const MorphingParticles = ({ count, theme, active, reducedMotion }: ParticlesPro
     const dt = Math.min(delta, 0.05);
     const uTime = points.current?.material.uniforms.uTime;
     if (uTime) uTime.value = state.clock.elapsedTime;
+    // Slow auto-spin (replaces OrbitControls autoRotate for the non-interactive bg).
+    if (points.current) points.current.rotation.y += dt * AUTO_ROTATE;
 
     if (m.theme !== theme || m.idx !== idx) {
       m.from.set(arr);
@@ -445,14 +452,19 @@ const MorphingParticles = ({ count, theme, active, reducedMotion }: ParticlesPro
   );
 };
 
-export const ParticleDisplay = ({ count = 10000 }: { count?: number }) => {
+/**
+ * Full-bleed ambient particle field rendered behind all page content.
+ * Non-interactive (pointer-events: none) so the page scrolls/clicks normally;
+ * it auto-cycles shapes and morphs to a company theme when an experience card
+ * is hovered/focused (via ParticleThemeProvider).
+ */
+export const ParticleBackground = ({ count = COUNT }: { count?: number }) => {
   const prefersReducedMotion = usePrefersReducedMotion();
   const { theme: ctxTheme } = useParticleTheme();
   const theme: ThemeKey = ctxTheme ?? "default";
-  const shapes = THEMES[theme];
   const [active, setActive] = useState(0);
 
-  // Auto-cycle within the current theme; a manual pick resets the timer.
+  // Auto-cycle through the active theme's shapes.
   useEffect(() => {
     if (prefersReducedMotion) return;
     const len = THEMES[theme].length;
@@ -460,67 +472,37 @@ export const ParticleDisplay = ({ count = 10000 }: { count?: number }) => {
     return () => clearInterval(id);
   }, [prefersReducedMotion, active, theme]);
 
+  // Gentle fade-in to the background opacity.
   useEffect(() => {
     if (prefersReducedMotion) return;
-    const fade_in_sequence: AnimationSequence = [
-      [".particle-display", { opacity: [0, 1] }, { duration: 4, at: 0 }],
+    const fade: AnimationSequence = [
+      [".particle-bg", { opacity: [0, BG_OPACITY] }, { duration: 3, at: 0 }],
     ];
-    void animate(fade_in_sequence);
+    void animate(fade);
   }, [prefersReducedMotion]);
 
-  const activeIdx = active % shapes.length;
-
   return (
-    <div className="flex w-full flex-col items-center gap-3">
-      <div
-        aria-hidden="true"
-        title="Drag to rotate · scroll to zoom · click to change shape"
-        onClick={() => setActive((a) => (a + 1) % THEMES[theme].length)}
-        className="particle-display flex aspect-square w-full max-w-[320px] items-center justify-center lg:max-w-[420px]"
+    <div
+      aria-hidden="true"
+      style={{ opacity: BG_OPACITY }}
+      className="particle-bg pointer-events-none fixed inset-0 -z-10"
+    >
+      <Canvas
+        camera={{
+          position: [1.5, 1.5, 1.5],
+          fov: 50,
+          near: 0.1,
+          far: 100,
+          zoom: CAMERA_ZOOM,
+        }}
       >
-        <Canvas
-          camera={{ position: [1.5, 1.5, 1.5], fov: 50, near: 0.1, far: 100, zoom: 2.4 }}
-        >
-          <OrbitControls
-            makeDefault
-            enablePan={false}
-            enableZoom
-            minDistance={1.2}
-            maxDistance={5}
-            enableDamping
-            autoRotate={!prefersReducedMotion}
-            autoRotateSpeed={0.6}
-          />
-          <MorphingParticles
-            count={count}
-            theme={theme}
-            active={active}
-            reducedMotion={prefersReducedMotion}
-          />
-        </Canvas>
-      </div>
-
-      <div
-        role="group"
-        aria-label="Particle shape"
-        className="flex flex-wrap justify-center gap-1.5"
-      >
-        {shapes.map((s, i) => (
-          <button
-            key={s.name}
-            type="button"
-            onClick={() => setActive(i)}
-            aria-pressed={activeIdx === i}
-            className={`rounded-full px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wide transition-colors ${
-              activeIdx === i
-                ? "bg-[#5786F5]/30 text-white"
-                : "bg-[#6071e2]/10 text-zinc-400 hover:text-white"
-            }`}
-          >
-            {s.name}
-          </button>
-        ))}
-      </div>
+        <MorphingParticles
+          count={count}
+          theme={theme}
+          active={active}
+          reducedMotion={prefersReducedMotion}
+        />
+      </Canvas>
     </div>
   );
 };

--- a/src/app/_components/main-screen.tsx
+++ b/src/app/_components/main-screen.tsx
@@ -4,7 +4,6 @@ import { animate, type AnimationSequence } from "motion";
 
 import NavList from "./homepage/nav-list";
 import Experience from "./experience-section";
-import { ParticleThemeProvider } from "./particle-theme";
 import { usePrefersReducedMotion } from "~/hooks/use-prefers-reduced-motion";
 
 export default function MainScreen() {
@@ -20,16 +19,14 @@ export default function MainScreen() {
   }, [prefersReducedMotion]);
 
   return (
-    <ParticleThemeProvider>
-      <div className="flex h-full max-w-screen-xl flex-col  items-center justify-between lg:flex-row lg:items-start">
-        <header className="left-col flex w-full flex-col items-center gap-4 py-12 lg:sticky lg:max-h-screen lg:w-1/2 lg:py-24">
-          <NavList />
-        </header>
+    <div className="flex h-full max-w-screen-xl flex-col  items-center justify-between lg:flex-row lg:items-start">
+      <header className="left-col flex w-full flex-col items-center gap-4 py-12 lg:sticky lg:max-h-screen lg:w-1/2 lg:py-24">
+        <NavList />
+      </header>
 
-        <div className="right-col flex h-full w-full justify-center lg:h-screen lg:w-1/2 lg:justify-normal">
-          <Experience />
-        </div>
+      <div className="right-col flex h-full w-full justify-center lg:h-screen lg:w-1/2 lg:justify-normal">
+        <Experience />
       </div>
-    </ParticleThemeProvider>
+    </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,7 +38,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`font-sans ${inter.variable} no-scrollbar overflow-x-hidden overflow-y-scroll lg:overflow-hidden`}
+        className={`font-sans ${inter.variable} no-scrollbar overflow-x-hidden overflow-y-scroll bg-zinc-900 bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))] lg:overflow-hidden`}
       >
         <a
           href="#experience"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,18 @@
 "use client";
 import { CustomCursor } from "./_components/custom-cursor";
 import MainScreen from "./_components/main-screen";
+import { ParticleThemeProvider } from "./_components/particle-theme";
+import { ParticleBackground } from "./_components/homepage/particle-display/particle-display";
 
 export default function Home() {
   return (
     <CustomCursor>
-      <main className="min-w-screen flex min-h-screen flex-row justify-center bg-zinc-900 bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))] text-white mix-blend-exclusion">
-        <MainScreen />
-      </main>
+      <ParticleThemeProvider>
+        <ParticleBackground />
+        <main className="min-w-screen flex min-h-screen flex-row justify-center text-white mix-blend-exclusion">
+          <MainScreen />
+        </main>
+      </ParticleThemeProvider>
     </CustomCursor>
   );
 }


### PR DESCRIPTION
Reworks the particle field from a card in the left column into a **non-interactive, full-page background** behind all content.

## Changes
- **`ParticleBackground`** — `fixed inset-0`, `pointer-events-none`, behind content (`-z-10`). Auto-cycles shapes, slowly auto-rotates, and still **morphs to a company theme on experience hover/focus**.
- Dropped the interactive bits (drag/zoom/click-to-change, toggle pills) — a full-page background can't capture pointer events without breaking page scroll/clicks. Auto-cycle + hover-to-theme remain.
- Lifted `ParticleThemeProvider` to `page.tsx` so the background and experience cards share one context.
- Removed the framed particle card from the left column (now just name/tagline + social icons).
- Moved the dark radial-gradient bg to `<body>`; `<main>` is transparent and keeps `mix-blend-exclusion`.
- **More particles (10k → 20k)** + tuning knobs at the top of `particle-display.tsx`: `COUNT`, `CAMERA_ZOOM`, `BG_OPACITY`, `AUTO_ROTATE`.

## ⚠️ Visual verification needed (please run locally)
Headless WebGL is down in my dev environment this session, so **I could not see the particles render**. Verified: `lint` ✓ `build` ✓ `smoke` ✓ (page renders, readable in the no-particle fallback, no JS errors). But please `npm run dev` and check, in particular:
1. **Readability** — text sits over the particle field with `mix-blend-exclusion`. If particles wash out the text, lower **`BG_OPACITY`** (currently 0.6) — or we drop the blend on text.
2. **Shape size/framing** — tune **`CAMERA_ZOOM`** (currently 3.0; higher = bigger).
3. **Density** — **`COUNT`** (currently 20000).
4. **Left-column balance** — without the card there's open space where particles now show through; tell me if the name/tagline/social need repositioning.

All four are single-number tweaks I can change without rendering — just tell me the direction (bigger/subtler/denser) and I'll dial them in.
