### PR TITLE
Denser particle background + fill the empty left column

### DIFF
--- a/src/app/_components/homepage/particle-display/particle-display.tsx
+++ b/src/app/_components/homepage/particle-display/particle-display.tsx
@@ -20,10 +20,10 @@ const RADIUS = 0.45;
 const MORPH_SECONDS = 1.6;
 const CYCLE_MS = 4200;
 
-// --- Background tuning knobs (safe to change by number; no WebGL needed) ---
-const COUNT = 20000; // particle count — higher = denser, bigger-feeling shapes
-const CAMERA_ZOOM = 3.0; // higher = the shape fills more of the screen
-const BG_OPACITY = 0.6; // overall background subtlety (readability vs presence)
+// --- Background tuning knobs (safe to change by number) ---
+const COUNT = 65000; // particle count — higher = denser, bigger-feeling shapes
+const CAMERA_ZOOM = 4.0; // higher = the shape fills more of the screen
+const BG_OPACITY = 0.9; // overall background presence (readability vs presence)
 const AUTO_ROTATE = 0.12; // radians/sec the field slowly spins
 
 type Build = (count: number) => Float32Array;

--- a/src/app/_components/homepage/particle-display/shaders/vertexShader.glsl
+++ b/src/app/_components/homepage/particle-display/shaders/vertexShader.glsl
@@ -12,7 +12,7 @@ void main() {
   vec3 dir = normalize(position + vec3(1e-4));
   vec3 particlePosition = position + dir * sin(uTime * 1.5 + d * 14.0) * 0.012;
 
-  float size = distanceFactor * 12.0 + 6.0;
+  float size = distanceFactor * 16.0 + 9.0;
 
   vDistance = distanceFactor;
 

--- a/src/app/_components/main-screen.tsx
+++ b/src/app/_components/main-screen.tsx
@@ -20,7 +20,7 @@ export default function MainScreen() {
 
   return (
     <div className="flex h-full max-w-screen-xl flex-col  items-center justify-between lg:flex-row lg:items-start">
-      <header className="left-col flex w-full flex-col items-center gap-4 py-12 lg:sticky lg:max-h-screen lg:w-1/2 lg:py-24">
+      <header className="left-col flex w-full flex-col items-center gap-4 py-12 lg:sticky lg:top-0 lg:h-screen lg:w-1/2 lg:py-24">
         <NavList />
       </header>
 


### PR DESCRIPTION
Follow-up to the full-bleed background: make it denser and fix the empty bottom-left.

## Changes
- **Much denser field:** 20k → **65k particles** with larger points (shader base size 12→16), and higher `CAMERA_ZOOM` (4.0) / `BG_OPACITY` (0.9) so it reads as a dense ambient backdrop filling the viewport instead of a faint smudge.
- **Empty bottom-left fixed:** left column is now full-height (`lg:h-screen`, sticky `top-0`), so the social icons pin to the bottom — name/tagline at top, particles glowing through the middle, social at the bottom. The void becomes the field's home.

## Verification
- I **fixed my local WebGL** (the blocker the last few turns): tiny `/dev/shm` + no virtual display → installed `xvfb`/`mesa`/`xauth` and render Chromium non-headless under `xvfb-run` with `--use-gl=egl`. So these are **verified with real screenshots**: the field is dense and fills the page, and the **Medtronic hover renders a large, recognizable heart**.
- `lint` ✓ `build` ✓ `smoke` ✓.

## Knobs / notes
- Tuning constants at the top of `particle-display.tsx`: `COUNT`, `CAMERA_ZOOM`, `BG_OPACITY`, `AUTO_ROTATE` — single-number tweaks.
- **Readability:** text sits over the now-dense field (`mix-blend-exclusion`). It's legible in my captures but busier than before; if you want calmer text, lower `BG_OPACITY`.
- **Mobile perf:** 65k full-screen particles is heavy for low-end phones (continuous render + transient morph CPU). If it janks on mobile, I can add a responsive count reduction (fewer particles on small screens).
