### PR TITLE
ci: bump GitHub Actions to current majors (Node 24)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Detect package manager
         id: detect-package-manager
@@ -51,16 +51,16 @@ jobs:
           fi
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "lts/*"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .next/cache
@@ -89,7 +89,7 @@ jobs:
         run: npm run smoke
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./out
 
@@ -103,4 +103,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Addresses the Node 20 deprecation warning from the last deploy (GitHub is forcing these actions to Node 24 by June 2, 2026).

Bumped to the current latest majors:
| action | before | after |
| --- | --- | --- |
| actions/checkout | v4 | **v6** |
| actions/setup-node | v4 | **v6** |
| actions/configure-pages | v4 | **v6** |
| actions/cache | v4 | **v5** |
| actions/upload-pages-artifact | v3 | **v5** |
| actions/deploy-pages | v4 | **v5** |

Inputs used (node-version, `cache`, artifact `path`) are unchanged across these majors, so it's a drop-in bump. The real exercise is the deploy run on merge — if anything regresses, the deploy fails safely (the live site stays on the last good publish until a green run).
