### PR TITLE
Fix particles invisible in Safari/iOS (drop mix-blend-exclusion)

### DIFF
--- a/src/app/_components/experience-section.tsx
+++ b/src/app/_components/experience-section.tsx
@@ -134,7 +134,7 @@ export default function Experience() {
       id="experience"
       tabIndex={-1}
       aria-label="Experience"
-      className="experience no-scrollbar flex h-full w-3/4 flex-col gap-4 text-zinc-300 mix-blend-exclusion lg:w-full lg:overflow-y-scroll lg:pr-24 lg:pt-24"
+      className="experience no-scrollbar flex h-full w-3/4 flex-col gap-4 text-zinc-300 lg:w-full lg:overflow-y-scroll lg:pr-24 lg:pt-24"
     >
       <h2 className="flex w-1/4 text-xs font-bold uppercase tracking-widest text-zinc-400 lg:sr-only">
         experience

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ export default function Home() {
     <CustomCursor>
       <ParticleThemeProvider>
         <ParticleBackground />
-        <main className="min-w-screen flex min-h-screen flex-row justify-center text-white mix-blend-exclusion">
+        <main className="min-w-screen flex min-h-screen flex-row justify-center text-white">
           <MainScreen />
         </main>
       </ParticleThemeProvider>


### PR DESCRIPTION
**Root cause found + reproduced.** Using Playwright's **WebKit** (Safari's engine) at a mobile viewport, the particle field rendered correctly (canvas sized, `gl: ok`, no errors) but was **invisible** — while it showed in Chromium. Isolated it by toggling the blend: removing `mix-blend-exclusion` made the particles appear in WebKit.

**Cause:** WebKit does not composite a `position: fixed` WebGL canvas *backdrop* through an element with `mix-blend-mode: exclusion` (a long-standing WebKit bug). Chromium composites it fine — which is exactly why every prior test (and desktop) worked.

**Fix:** remove `mix-blend-exclusion` from `<main>` and the experience section. The cursor keeps its `mix-blend-difference` (small element, doesn't block the field).

Verified: particles now render in WebKit @ 390×844; desktop (Chromium) still looks good — actually **more vivid** (the blend was muting the particles) and the text is crisper. `lint`/`build`/`smoke` ✓.

Trade-off: the desktop "inverted text" look from the blend is gone. Given the particle field is now the centerpiece and the blend made it invisible on Safari/iOS, this is the right call — but flagging it since you'd previously liked the blend.
