### PR TITLE
Temporary on-device WebGL diagnostic (?debug)

### DIFF
--- a/src/app/_components/webgl-debug.tsx
+++ b/src/app/_components/webgl-debug.tsx
@@ -1,0 +1,70 @@
+"use client";
+import { useEffect, useState } from "react";
+
+/**
+ * Temporary on-device diagnostic. Renders a small readout ONLY when the URL has
+ * `?debug` (e.g. rounsifer.github.io/?debug=1), so the real site stays clean.
+ * Used to see why the WebGL particle field isn't appearing on a specific phone.
+ */
+export function WebGLDebug() {
+  const [info, setInfo] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!window.location.search.includes("debug")) return;
+    const lines: string[] = [];
+    try {
+      const c = document.createElement("canvas");
+      const gl2 = c.getContext("webgl2");
+      const gl = gl2 ?? c.getContext("webgl");
+      lines.push(`webgl2: ${gl2 ? "YES" : "no"}`);
+      lines.push(`webgl1: ${gl ? "yes" : "NO"}`);
+      if (gl) {
+        const dbg = gl.getExtension("WEBGL_debug_renderer_info");
+        lines.push(
+          `gpu: ${dbg ? String(gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL)) : "(masked)"}`,
+        );
+      }
+      const cv = document.querySelector("canvas");
+      const r = cv?.getBoundingClientRect();
+      lines.push(
+        `pageCanvas: ${cv ? `${Math.round(r!.width)}x${Math.round(r!.height)}` : "MISSING"}`,
+      );
+      lines.push(`dpr: ${window.devicePixelRatio} | w: ${window.innerWidth}`);
+      lines.push(
+        `reduceMotion: ${window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "ON" : "off"}`,
+      );
+      lines.push(`ua: ${navigator.userAgent}`);
+    } catch (e) {
+      lines.push(`ERROR: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time debug readout
+    setInfo(lines.join("\n"));
+
+    const onErr = (e: ErrorEvent) =>
+      setInfo((p) => `${p ?? ""}\nJS ERR: ${e.message}`);
+    window.addEventListener("error", onErr);
+    return () => window.removeEventListener("error", onErr);
+  }, []);
+
+  if (info === null) return null;
+  return (
+    <pre
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        zIndex: 99999,
+        margin: 0,
+        padding: "8px",
+        maxWidth: "100vw",
+        whiteSpace: "pre-wrap",
+        wordBreak: "break-word",
+        background: "rgba(0,0,0,0.9)",
+        color: "#3f3",
+        font: "11px/1.4 monospace",
+      }}
+    >
+      {info}
+    </pre>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { CustomCursor } from "./_components/custom-cursor";
 import MainScreen from "./_components/main-screen";
 import { ParticleThemeProvider } from "./_components/particle-theme";
 import { ParticleBackground } from "./_components/homepage/particle-display/particle-display";
+import { WebGLDebug } from "./_components/webgl-debug";
 
 export default function Home() {
   return (
@@ -13,6 +14,7 @@ export default function Home() {
           <MainScreen />
         </main>
       </ParticleThemeProvider>
+      <WebGLDebug />
     </CustomCursor>
   );
 }


### PR DESCRIPTION
Temporary diagnostic gated behind `?debug=1` to capture real-device WebGL info (the particle field isn't visible on a specific phone and headless browsers can't reproduce it). Will be removed once we have the data.